### PR TITLE
Upgrade tonic to 0.13 and tower to 0.5

### DIFF
--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -15,8 +15,8 @@ async-trait = "0.1"
 http = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.12", features = ["tls"] }
-tower = { version = "0.4", default-features = false, features = ["discover"] }
+tonic = { version = "0.13", features = ["tls-ring"] }
+tower = { version = "0.5", default-features = false, features = ["discover"] }
 tracing = "0.1"
 hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 

--- a/ginepro/src/service_probe.rs
+++ b/ginepro/src/service_probe.rs
@@ -3,8 +3,10 @@ use std::collections::HashSet;
 use std::net::SocketAddr;
 use tokio::sync::mpsc::Sender;
 use tokio::time::Duration;
-use tonic::transport::{channel::Endpoint, ClientTlsConfig};
-use tower::discover::Change;
+use tonic::transport::{
+    channel::{Change, Endpoint},
+    ClientTlsConfig,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProbeError {
@@ -244,13 +246,13 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
         if let Some(ref connect_timeout) = self.endpoint_connect_timeout {
             endpoint = endpoint.connect_timeout(*connect_timeout)
         }
-        if let Some(ref timeout) = self.keep_alive_timeout{
+        if let Some(ref timeout) = self.keep_alive_timeout {
             endpoint = endpoint.keep_alive_timeout(*timeout);
         }
-        if let Some(ref inteval) = self.http2_keep_alive_interval{
+        if let Some(ref inteval) = self.http2_keep_alive_interval {
             endpoint = endpoint.http2_keep_alive_interval(*inteval);
         }
-        if self.keep_alive_while_idle{
+        if self.keep_alive_while_idle {
             endpoint = endpoint.keep_alive_while_idle(true);
         }
 

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 prost = "0.13"
-tonic = "0.12"
+tonic = "0.13"
 
 [build-dependencies]
-tonic-build = "0.12"
+tonic-build = "0.13"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ hyper = "1"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.12", features = ["tls"] }
+tonic = { version = "0.13", features = ["tls-ring"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = "0.12"
+tonic-health = "0.13"

--- a/tests/src/test_server.rs
+++ b/tests/src/test_server.rs
@@ -7,7 +7,7 @@ use std::{
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{
-    body::BoxBody,
+    body::Body,
     transport::{
         server::{Router, Server},
         ServerTlsConfig,
@@ -45,10 +45,11 @@ impl TestServer {
         tls: Option<ServerTlsConfig>,
     ) -> Self
     where
-        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+        S: Service<Request<Body>, Response = Response<Body>, Error = Infallible>
             + NamedService
             + Clone
             + Send
+            + Sync
             + 'static,
         S::Future: Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send,
@@ -86,10 +87,9 @@ impl TestServer {
     pub async fn start_with_router<L, T>(router: Router<L>, address: T) -> TestServer
     where
         L: Layer<Routes> + Send + 'static,
-        L::Service:
-            Service<Request<BoxBody>, Response = Response<BoxBody>> + Clone + Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
+        L::Service: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error:
             Into<Box<dyn std::error::Error + Send + Sync>> + Send,
         T: Into<Option<String>>,
     {


### PR DESCRIPTION
<!-- Please explain the changes you made -->
This PR upgrades tonic to 0.13 and tower to 0.5.

A couple of source code changes were needed for the upgrade to work:

* Replace tonic `tls` feature with `tls-ring`.
* Replace `tower::discover::Change` with `tonic::transport::channel::Change`.
* Replace `tonic:body:BoxBody` with `tonic:body:Body`.
* Test code changes: mark `S` generic as `Sync` on `start()`.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/ginepro/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/ginepro/blob/main/CHANGELOG.md
-->
